### PR TITLE
remove newsletter with hubspot snippet to test blank-page theory

### DIFF
--- a/src/app/Document.tsx
+++ b/src/app/Document.tsx
@@ -9,7 +9,7 @@ export const Document: React.FC<{ children: React.ReactNode }> = ({ children }) 
       <link rel="icon" href="/favicon.ico" />
       <link rel="preconnect" href="https://rsms.me/" />
       <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
-      <script defer src="https://js.hsforms.net/forms/v2.js"></script>
+      {/* <script defer src="https://js.hsforms.net/forms/v2.js"></script> */}
     </head>
     <body>
       <div id="root">{children}</div>

--- a/src/app/contentTheme/Footer.tsx
+++ b/src/app/contentTheme/Footer.tsx
@@ -17,8 +17,8 @@ export function Footer() {
       <div className="flex flex-wrap justify-center gap-4">
         {footer?.links.map((link) => <ButtonLink href={link.href} text={link.text} key={link.href} />)}
       </div>
-      <hr className="w-full mt-8 border-gray-500" />
-      <NewsletterForm />
+      {/* <hr className="w-full mt-8 border-gray-500" /> */}
+      {/* <NewsletterForm /> */}
       <hr className="w-full my-0 border-gray-500" />
       <div className="whitespace-pre-line text-center text-sm">{`FUTURE MEDIA CONCEPTS, INC.
         P.O. Box 1882


### PR DESCRIPTION
Sometimes when re-opening the site after closing the browser (open on the last page in browser history), the page appears blank until manually reloaded.

One theory is that the hubspot code in https://js.hsforms.net/forms/v2.js is the cause. This PR removes that code to see if the problem goes away.

It's a 500kB minified, 34 kloc p.o.s -- it would be much better to provide our own form and call the hs api instead. 

 