### PR TITLE
Fix 404 with client-side nav

### DIFF
--- a/src/app/contentTheme/404.tsx
+++ b/src/app/contentTheme/404.tsx
@@ -8,9 +8,8 @@ export function NotFound() {
     <ContentLayout>
       <div className="prose prose-invert mx-auto max-w-3xl">
         <h1 id="404" className="text-3xl sm:text-4xl md:text-5xl">
-          404
+          Page not found
         </h1>
-        <p>Page not found</p>
         <p>{r.request.url}</p>
       </div>
     </ContentLayout>

--- a/src/app/contentTheme/ContentTheme.tsx
+++ b/src/app/contentTheme/ContentTheme.tsx
@@ -30,6 +30,10 @@ export async function ContentTheme({ ctx, request }: RequestInfo) {
     // TODO: replace with requestInfo.status = 404 when available
     // https://github.com/redwoodjs/sdk/issues/568
     console.log(`404: ${request.url}`)
+    const url = new URL(request.url)
+    if (url.searchParams.has('__rsc')) {
+      return <NotFound />
+    }
     return new Response(await renderToStream(<NotFound />, { Document }), {
       status: 404
     })

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -1,4 +1,6 @@
 import { initClient, initClientNavigation } from 'rwsdk/client'
 
-initClient()
-initClientNavigation()
+if (!document.getElementById('404')) {
+  const { handleResponse } = initClientNavigation()
+  initClient({ handleResponse })
+}


### PR DESCRIPTION
https://discord.com/channels/679514959968993311/1400145352706756779
- regular nav (land on unknown page) return rendered HTML with "Page not Found" and HTTP response status 404
- client-side nav - show same page without the 404 status 
<img width="1274" height="436" alt="Screenshot 2025-07-30 at 19 41 26" src="https://github.com/user-attachments/assets/f460bf11-8ade-48d7-bde5-1753d6eaee00" />
